### PR TITLE
Hsts

### DIFF
--- a/server/app.js
+++ b/server/app.js
@@ -16,11 +16,14 @@ db.createTables().then(function() {
 	process.kill(1);
 	return;
 });
-app.enable('trust proxy');
+
 app.use( hsts({
 	maxAge : 604800000,
+	includeSubdomains : true,
 	force : true
  }));
+
+app.enable('trust proxy');
 
 if(process.env.NODE_ENV !== 'development'){
 	app.use(enforceSSL());	

--- a/server/app.js
+++ b/server/app.js
@@ -16,7 +16,7 @@ db.createTables().then(function() {
 	process.kill(1);
 	return;
 });
-
+app.enable('trust proxy');
 app.use( hsts({
 	maxAge : 604800000,
 	force : true


### PR DESCRIPTION
The heroku app is behind a proxy, so our Express app goes into an infinite redirect loop when we try to force HTTPS. This resolves that.
