### PR TITLE
Add small chart to contrast area to give more detail

### DIFF
--- a/client/src/js/main.js
+++ b/client/src/js/main.js
@@ -1,0 +1,51 @@
+'use strict';
+const Chart = require('chart.js');
+
+// Add the accessibility chart
+const chartWrapper = document.getElementById('contrastChartWrapper');
+const url = decodeURIComponent(location.search.split('url=')[1].split('&')[0]);
+const chartData = location.search.split('data=')[1].split(',').map(Number).map(n => n.toFixed(2)).map(Number);
+const canvas = document.createElement('canvas');
+const width = 480;
+canvas.width = width;
+canvas.height = width / 1.5;
+const title = document.createElement('h3');
+chartWrapper.appendChild(title);
+title.innerHTML = `Contrast Ratio for: <a href="${url}" target="_blank">${url}</a>`;
+const yLegend = document.createElement('div');
+chartWrapper.appendChild(yLegend);
+yLegend.innerHTML = 'Proportion of Characters';
+const ctx = canvas.getContext('2d');
+chartWrapper.appendChild(canvas);
+const xLegend = document.createElement('div');
+chartWrapper.appendChild(xLegend);
+xLegend.innerHTML = 'Contrast Ratio (Higher is better)';
+xLegend.style.textAlign = 'right';
+
+const grd = ctx.createLinearGradient(0.000, 150.000, width, 150.000);
+
+// Add colors
+grd.addColorStop(0.000, 'rgba(255, 0, 0, 1.000)');
+grd.addColorStop(0.470, 'rgba(219, 178, 30, 1.000)');
+grd.addColorStop(1.000, 'rgba(95, 191, 0, 1.000)');
+
+const line = new Chart(ctx).Line({
+	labels: [0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,'15+'],
+	datasets: [{
+		label: 'Contrast',
+		fillColor: grd,
+		strokeColor: 'rgba(220,220,220,1)',
+		pointColor: 'rgba(220,220,220,1)',
+		pointStrokeColor: '#fff',
+		pointHighlightFill: '#fff',
+		pointHighlightStroke: 'rgba(220,220,220,1)',
+		data: chartData
+	}]
+}, {
+	pointDot: false,
+	pointHitDetectionRadius : 0,
+	scaleOverride: true,
+	scaleSteps: 5,
+	scaleStepWidth: 0.2,
+	scaleStartValue: 0
+});

--- a/extension/scripts/background.js
+++ b/extension/scripts/background.js
@@ -51,7 +51,7 @@ function* getData (url, freshInsights) {
 	yield makeAPICall();
 
 	while (lastStatus === 202) {
-		yield waitThen(makeAPICall, 1000);
+		yield waitThen(makeAPICall, 3000);
 	}
 
 	if (lastStatus === 200) {

--- a/extension/scripts/main.js
+++ b/extension/scripts/main.js
@@ -35,7 +35,7 @@ function nodesWithTextNodesUnder (el) {
 function getBackgroundColorForEl (el) {
 
 	const bgc = window.getComputedStyle(el).backgroundColor;
-	if (bgc !== noColorCalculatedStyle && bgc != "") {
+	if (bgc !== noColorCalculatedStyle && bgc !== '') {
 		return bgc;
 	} else if (el.parentNode) {
 		return getBackgroundColorForEl(el.parentNode);

--- a/extension/scripts/main.js
+++ b/extension/scripts/main.js
@@ -168,7 +168,7 @@ function loadWidget () {
 					const canvas = document.createElement('canvas');
 					const width = chartWrapper.clientWidth;
 					canvas.width = width;
-					canvas.height = width / 2;
+					canvas.height = width / 1.5;
 					const ctx = canvas.getContext('2d');
 					chartWrapper.appendChild(canvas);
 
@@ -192,9 +192,12 @@ function loadWidget () {
 							data: chartData
 						}]
 					}, {
-						scaleShowGridLines: false,
 						pointDot: false,
-						pointHitDetectionRadius : 0
+						pointHitDetectionRadius : 0,
+						scaleOverride: true,
+						scaleSteps: 5,
+						scaleStepWidth: 0.2,
+						scaleStartValue: 0
 					});
 
 				}

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -8,8 +8,9 @@ const webpack = require('gulp-webpack');
 const argv = require('yargs').argv;
 const serverDomain = process.env.SERVER_DOMAIN || 'https://ftlabs-perf-widget-test.herokuapp.com';
 const base64 = require('gulp-base64');
+const obt = require('origami-build-tools');
 
-function getDestination(){
+function getDestination () {
 
 	const locations = {
 		LIVE : 'https://ftlabs-perf-widget.herokuapp.com',
@@ -26,7 +27,19 @@ function getDestination(){
 
 }
 
-gulp.task('set-service-url', function (){
+gulp.task('obt', function () {
+
+	return obt.build(gulp, {
+		js: './client/src/js/main.js',
+		// sass: './client/src/scss/main.scss',
+		buildJs: 'contrast-bundle.js',
+		// buildCss: 'bundle.css',
+		buildFolder: './client/dist/'
+	});
+
+});
+
+gulp.task('set-service-url', function () {
 
 	return gulp.src('./client/dist/*.js')
 		.pipe(preprocess( { context : { serviceURL : getDestination() } } ) )
@@ -35,20 +48,20 @@ gulp.task('set-service-url', function (){
 
 });
 
-gulp.task('build-extension-main', ['copy-extension-files'], function(){
+gulp.task('build-extension-main', ['copy-extension-files'], function () {
 
 	gulp.src('./extension/scripts/main.js')
 	.pipe(webpack({output: {
 		filename: 'main.js',
 	}}))
-	.pipe(preprocess( { context : { serviceURL : process.env.NODE_ENV === "development" ? 'http://localhost:3000' : serverDomain } } ))
+	.pipe(preprocess( { context : { serviceURL : getDestination() } } ) )
 	.pipe(base64({
 		baseDir: 'client/src/'
 	}))
 	.pipe(gulp.dest('./extension-dist/scripts/'));
 });
 
-gulp.task('build-extension-background', ['copy-extension-files'], function(){
+gulp.task('build-extension-background', ['copy-extension-files'], function () {
 
 	gulp.src('./extension/scripts/background.js')
 	.pipe(webpack({output: {
@@ -58,21 +71,20 @@ gulp.task('build-extension-background', ['copy-extension-files'], function(){
 	.pipe(gulp.dest('./extension-dist/scripts/'));
 });
 
-gulp.task('build-extension-popup', ['copy-extension-files'], function(){
+gulp.task('build-extension-popup', ['copy-extension-files'], function () {
 	gulp.src('./extension/scripts/popup.js')
 	.pipe(gulp.dest('./extension-dist/scripts/'));
 });
 
-gulp.task('build-extension-manifest', ['copy-extension-files'], function(){
+gulp.task('build-extension-manifest', ['copy-extension-files'], function () {
 	gulp.src('./extension/manifest.json')
 	.pipe(preprocess( {context : { serviceURL : getDestination() } } ) )
 	.pipe(gulp.dest('./extension-dist/'));
 });
 
-
 gulp.task('build-extension', ['build-extension-main', 'build-extension-background', 'build-extension-popup', 'build-extension-manifest']);
 
-gulp.task('copy-extension-files', function(){
+gulp.task('copy-extension-files', function () {
 
 	return gulp.src([
 		'extension/*'

--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
     "mysql": "^2.10.2",
     "node-ssllabs": "^0.4.3",
     "npm-run-all": "^1.4.0",
-    "origami-build-tools": "^4.3.2",
+    "origami-build-tools": "^4.5.2",
     "psi": "^2.0.2",
     "raven": "^0.9.0",
     "yargs": "^3.32.0"
@@ -61,13 +61,14 @@
     "supertest": "^1.1.0"
   },
   "scripts": {
-    "build": "npm-run-all clean copy build:app build:extension",
+    "build": "npm-run-all clean mkdir build:app build:extension build:obt",
     "build:app": "gulp set-service-url",
+    "build:obt": "gulp obt",
     "build:extension": "gulp build-extension",
     "build:extension:test": "gulp build-extension --destination TEST",
     "build:extension:live": "gulp build-extension --destination LIVE",
     "clean": "rimraf client/dist/ extension-dist/",
-    "copy": "mkdir -p client/dist && cp -r ./client/src/images ./client/dist",
+    "mkdir": "mkdir -p client/dist",
     "develop": "npm run watch -- --exec 'npm-run-all -p start build'",
     "lint": "obt verify --excludeFiles=\\!client/src/js/**/*.js",
     "postinstall": "npm run build",

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
     "babel-preset-es2015": "^6.3.13",
     "bluebird": "^3.1.5",
     "body-parser": "^1.14.1",
+    "chart.js": "^1.0.2",
     "debug": "^2.2.0",
     "denodeify": "^1.2.1",
     "dotenv": "^1.2.0",

--- a/server/routes/contrast.js
+++ b/server/routes/contrast.js
@@ -1,0 +1,5 @@
+module.exports = function (req, res){
+
+	res.render('contrast');
+
+}

--- a/server/routes/index.js
+++ b/server/routes/index.js
@@ -3,6 +3,7 @@ const router = require('express').Router(); //eslint-disable-line new-cap
 // Serve static assets from /static
 router.get('/', require('./home'));
 router.get('/insights', require('./insights'));
+router.get('/contrastbreakdown', require('./contrast'));
 router.use('/static', require('./staticFiles'));
 router.use('/api', require('./api'));
 

--- a/server/views/contrast.hbs
+++ b/server/views/contrast.hbs
@@ -86,7 +86,7 @@
 		</main>
 
 		<script src="https://origami-buildservice-qa.herokuapp.com/bundles/js?modules=o-techdocs@^5.0.1,o-fonts@^1.6.4" async defer></script>
-		<script src="/contrast-bundle.js" async defer></script>
+		<script src="/static/contrast-bundle.js" async defer></script>
 
 	</body>
 

--- a/server/views/contrast.hbs
+++ b/server/views/contrast.hbs
@@ -1,0 +1,93 @@
+<!DOCTYPE html>
+<html>
+
+	<head>
+
+		<title>FT Labs Perf-Widget</title>
+		<link rel="stylesheet" href="https://origami-buildservice-qa.herokuapp.com/bundles/css?modules=o-techdocs@^5.0.1,o-fonts@^1.6.4" />
+
+		<style type="text/css">
+			html, body {
+				font-family: BentonSans;
+				margin: 0;
+				margin-bottom: 5em;
+			}
+
+			h3:target + div {
+				border: 1px solid #ccc;
+			}
+
+			.o-techdocs-content div {
+				margin: 0 -1em;
+				padding: 0 1em;
+				border-radius: 1em;
+			}
+
+			#contrastChartWrapper {
+				display: inline-block;
+				float: right;
+				margin-left: 1em;
+				border: 1px solid #ccc;
+				border-radius: 1em;
+				padding: 0.5em;
+			}
+
+			#contrastChartWrapper h3 {
+				margin: 0 0 1em 0;
+				text-align: center;
+				width: 480px;
+				overflow: hidden;
+			}
+
+		</style>
+
+	</head>
+
+	<body>
+
+		<header data-o-component="o-header" class="o-header">
+			<div class="o-header__container">
+				<div class="o-header__inner">
+					<div class="o-header__primary">
+						<div class="o-header__primary__left">
+							<a class="o-header__logo o-header__logo--ft" href="http://labs.ft.com">
+								<abbr title="Financial Times">FT</abbr>
+							</a>
+						</div>
+					</div>
+				</div>
+			</div>
+		</header>
+
+		<main>
+			<div class="o-techdocs-hero">
+				<h2 class="o-techdocs-hero__title">
+					FT Labs Perf-Widget Chrome Extension and Service
+				</h2>
+			</div>
+
+			<div class="o-techdocs-container">
+				<div class="o-techdocs-main">
+
+					<div class="o-techdocs-content">
+					<h2>Contrast Analysis</h2>
+					<div id="contrastChartWrapper"></div>
+
+					<p>This insight provides information about the legibility of your site.</p>
+					<p>It compares the css text colour to the css background colour for block of text on the page.</p>
+					<p>It then works out the contrast ratio (a number between 0 and 21). It is based upon <a href="http://leaverou.github.io/contrast-ratio/">this tool by Lea Verou.</a> Where 1 is no contrast (same colour) and 21 is comparing white to black</p>
+					<p>A rating of below 4 is poor contrast and should be considered illegible.</p>
+					<p>The tool measures that enough of the site is above a threshold of 4 and provides a small graph showing what proportion of the text on your page is legible.</p>
+
+				</div>
+
+			</div>
+
+		</main>
+
+		<script src="https://origami-buildservice-qa.herokuapp.com/bundles/js?modules=o-techdocs@^5.0.1,o-fonts@^1.6.4" async defer></script>
+		<script src="/contrast-bundle.js" async defer></script>
+
+	</body>
+
+</html>


### PR DESCRIPTION
The existing a11y section lacks, much detail and a simple it's okay/not okay is inadequate for detailed view as most of the page could be great but some elements may be terrible. A graph lets one see just how bad the bad elements are.

![image](https://cloud.githubusercontent.com/assets/4225330/12925767/c9c57058-cf14-11e5-9a8e-e003a1f83918.png)

![image](https://cloud.githubusercontent.com/assets/4225330/12925775/d7667fae-cf14-11e5-8762-f1e5aa2955a1.png)

I also removed the automatic console logging of bad elements.
