### PR TITLE
Catch SQL query errors and release the connection back to the pool.

### DIFF
--- a/server/lib/database.js
+++ b/server/lib/database.js
@@ -47,6 +47,9 @@ module.exports.query = function query (command) {
 		return query(command).then(function (results) {
 			connection.release();
 			return results;
+		}).catch(err => {
+			debug('>>>>>>> SQL ERROR <<<<<<<\n\n', command, '>>>\n\n', err, '\n\n>>>>>>> |||||||| <<<<<<<');
+			connection.release();
 		});
 	});
 };

--- a/server/lib/insightProviders/pageInsightProviders/googlePageSpeedInsights.js
+++ b/server/lib/insightProviders/pageInsightProviders/googlePageSpeedInsights.js
@@ -5,6 +5,7 @@ const psi = require('psi');
 module.exports = function googlePageSpeedInsights(url) {
 
 	return psi(url).then(function(results) {
+
 		return [{
 			name: 'PageSpeedInsightsScore',
 			value: parseInt(results.ruleGroups.SPEED.score, 10),
@@ -19,11 +20,11 @@ module.exports = function googlePageSpeedInsights(url) {
 			link: `https://developers.google.com/speed/pagespeed/insights/?url=${url}&tab=mobile`
 		},{
 			name: 'WeightOfResources',
-			value: parseInt(results.pageStats.htmlResponseBytes, 10) + 
-					parseInt(results.pageStats.cssResponseBytes, 10) + 
-					parseInt(results.pageStats.imageResponseBytes, 10) + 
-					parseInt(results.pageStats.javascriptResponseBytes, 10) + 
-					parseInt(results.pageStats.otherResponseBytes, 10),
+			value: parseInt(results.pageStats.htmlResponseBytes, 10) || 0 + 
+					parseInt(results.pageStats.cssResponseBytes, 10) || 0 + 
+					parseInt(results.pageStats.imageResponseBytes, 10) || 0 + 
+					parseInt(results.pageStats.javascriptResponseBytes, 10) || 0 + 
+					parseInt(results.pageStats.otherResponseBytes, 10) || 0,
 			link: `https://developers.google.com/speed/pagespeed/insights/?url=${url}&tab=mobile`
 		}];
 	});


### PR DESCRIPTION
Handle circumstance where Google PageSpeed returns values that don't parse as intgers and result in NaN
