### PR TITLE
Add logging for insight provider timings

### DIFF
--- a/server/lib/insightProviders/domainInsightProviders/sslLabs.js
+++ b/server/lib/insightProviders/domainInsightProviders/sslLabs.js
@@ -1,7 +1,7 @@
+const debug = require('debug')('perf-widget:lib:insightsProviders:domainInsightProviders:sslLabs'); // eslint-disable-line no-unused-vars
 const ssllabs = require("node-ssllabs");
 const denodeify = require('denodeify');
 const scan = denodeify(ssllabs.scan.bind(ssllabs));
-const debug = require('debug')('perf-widget:lib:insightsProviders:domainInsightProviders:sslLabs'); // eslint-disable-line no-unused-vars
 
 const g = {
 	A : 1,
@@ -14,8 +14,9 @@ const g = {
 };
 
 module.exports = function (url) {
-
+	console.time('SSL-Labs');
 	return scan(url).then(function(results) {
+		debug(console.timeEnd('SSL-Labs'));
 
 		const grade = results.endpoints[0].grade === undefined ? null : g[results.endpoints[0].grade[0]];
 

--- a/server/lib/insightProviders/pageInsightProviders/googlePageSpeedInsights.js
+++ b/server/lib/insightProviders/pageInsightProviders/googlePageSpeedInsights.js
@@ -4,7 +4,10 @@ const psi = require('psi');
 
 module.exports = function googlePageSpeedInsights(url) {
 
+	console.time('PSI');
+
 	return psi(url).then(function(results) {
+		debug(console.timeEnd('PSI'));
 
 		return [{
 			name: 'PageSpeedInsightsScore',


### PR DESCRIPTION
Related to #84

Example by tailing the logs

> GET /api/data-for?url=http://next.ft.com 202 7.513 ms - 65
> PSI: 16828.248ms
